### PR TITLE
updated to issues 1 & 3

### DIFF
--- a/fstab.py
+++ b/fstab.py
@@ -24,18 +24,12 @@ else:
     SANDBOX = os.environ['SANDBOX']
     print('Enabling Sandbox at:', SANDBOX)
     msg = "%s %s %s %s" % (get_linenumber(), ":Enabling Sandbox at:", SANDBOX, '')
-    message(msg, 1)
+    message(msg, D1)
 
 FSTAB = SANDBOX + DEFAULT_FSTAB_FILE
 DEVDIR = SANDBOX + DEFAULT_DEVDIR
 DEV_UUID = SANDBOX + DEFAULT_DEV_UUID_DIR
 
-# msg = "%s %s %s" % (get_linenumber(), ":FSTAB:", FSTAB, '')
-# message(msg, 1)
-# msg = "%s %s %s" % (get_linenumber(), ":DEVDIR:", DEVDIR, '')
-# message(msg, 1)
-# msg = "%s %s %s" % (get_linenumber(), ":DEV_UUID:", DEV_UUID, '')
-# message(msg, 1)
 
 def unit_test_result(name, status):
     print("%-30s %-10s" % (name, status))
@@ -48,7 +42,7 @@ def fs_uuid_to_path(uuid):
     """
     path = DEV_UUID
     msg = "%s %s %s %s" % (get_linenumber(), ":fs_uuid_to_path: input->", uuid, '')
-    message(msg, 1)
+    message(msg, D1)
 
 
     # strip 'UUID="..."'chars from input
@@ -59,7 +53,7 @@ def fs_uuid_to_path(uuid):
     path = path + "/" + tmp2
 
     msg = "%s %s %s %s" % (get_linenumber(), ":fs_uuid_to_path: returning->", path, '')
-    message(msg, 1)
+    message(msg, D1)
 
     return path
 
@@ -158,7 +152,7 @@ def parse_fstab(file_name=FSTAB):
 
 
     msg = "%s %s %s" % (get_linenumber(), ":Beginning parse_fstab", file_name)
-    message(msg, 1)
+    message(msg, D1)
 
     with open(file_name, "r") as f:
         for line in f:
@@ -249,7 +243,7 @@ def parse_fstab(file_name=FSTAB):
                       }
 
     msg = "%s%s" % (get_linenumber(), " :End parse_fstab")
-    message(msg, 1)
+    message(msg, D1)
 
     return fstab
 

--- a/fstab.py
+++ b/fstab.py
@@ -23,8 +23,7 @@ if not os.getenv('SANDBOX'):
 else:
     SANDBOX = os.environ['SANDBOX']
     print('Enabling Sandbox at:', SANDBOX)
-    msg = "%s %s %s" % (get_linenumber(), ":Enabling Sandbox at:", SANDBOX, '')
-    msg = "%s %s %s" % (get_linenumber(), ":", '', '')
+    msg = "%s %s %s %s" % (get_linenumber(), ":Enabling Sandbox at:", SANDBOX, '')
     message(msg, 1)
 
 FSTAB = SANDBOX + DEFAULT_FSTAB_FILE
@@ -48,8 +47,8 @@ def fs_uuid_to_path(uuid):
         Output: /dev/disk/by-uuid/eb0caaa8-8191-490d-b955-f3a73ed6fe26
     """
     path = DEV_UUID
-    msg = "%s %s %s" % (get_linenumber(), ":fs_uuid_to_path: input->", uuid, '')
-    message(msg, D1)
+    msg = "%s %s %s %s" % (get_linenumber(), ":fs_uuid_to_path: input->", uuid, '')
+    message(msg, 1)
 
 
     # strip 'UUID="..."'chars from input
@@ -59,8 +58,8 @@ def fs_uuid_to_path(uuid):
     # append UUID to path
     path = path + "/" + tmp2
 
-    msg = "%s %s %s" % (get_linenumber(), ":fs_uuid_to_path: returning->", path, '')
-    message(msg, D1)
+    msg = "%s %s %s %s" % (get_linenumber(), ":fs_uuid_to_path: returning->", path, '')
+    message(msg, 1)
 
     return path
 
@@ -244,7 +243,9 @@ def parse_fstab(file_name=FSTAB):
                         'pm_ns_name': 'namespaceX.Y', \
                         'pm_ns_dev': block_dev, \
                         'pm_ns_type': 'fsdaX', \
-                        'dimms': 'dimms' \
+                        'dimms': 'dimms', \
+                        'mounted': 'T/F', \
+                        'size': 'NaN', \
                       }
 
     msg = "%s%s" % (get_linenumber(), " :End parse_fstab")
@@ -254,34 +255,40 @@ def parse_fstab(file_name=FSTAB):
 
 def print_fstab_table(fstab):
 
-    print("%-6s %-8s %-10s %-8s %-8s %-20s %20s" % ( \
-            'Health', \
-            'Region', \
-            'NS dev', \
-            'NS Type', \
-            'fs_type', \
-            'mount', \
-            'dimms'))
+    print("%-12s" % ( 'Mount Point'), end = ' ')
+    print("%-7s" % ( 'Mounted'), end = ' ')
+    print("%-9s" % ( 'NS Size'), end = ' ')
+    print("%-8s" % ( 'Health'), end = ' ')
+    print("%-10s" % ( 'Region'), end = ' ')
+    print("%-8s" % ( 'NS dev'), end = ' ')
+    print("%-8s" % ( 'NS Type'), end = ' ')
+    print("%-8s" % ( 'fs_type'), end = ' ')
+    print("%-20s" % ( 'PMEM Devices'), end = ' ')
+    print()
 
-    print("%-6s %-8s %-10s %-8s %-8s %-20s %20s" % (\
-            '------',
-            '-------',
-            '------',
-            '------',
-            '------',
-            '--------------------',
-            '--------------------'\
-            ))
+    print("%-12s" % ( '------------'), end=' ')
+    print("%-7s"  % ( '-------'), end=' ')
+    print("%9s"   % ( '---------'), end=' ')
+    print("%8s"   % ( '--------'), end=' ')
+    print("%-10s" % ( '----------'), end=' ')
+    print("%-8s"  % ( '--------'), end=' ')
+    print("%-8s"  % ( '--------'), end=' ')
+    print("%-8s"  % ( '--------'), end=' ')
+    print("%-20s"  % ( '--------------------------------------'), end=' ')
+    print()
+
     for k in fstab.keys():
-        print("%-6s %-8s %-10s %-8s %-8s %-20s %-20s" % ( \
-               fstab[k]['status'], \
-               fstab[k]['pm_region'], \
-               fstab[k]['pm_ns_dev'], \
-               fstab[k]['pm_ns_type'], \
-               fstab[k]['fs_type'], \
-               fstab[k]['mount'], \
-               fstab[k]['dimms'] \
-               ))
+        print("%-12s" % ( fstab[k]['mount']), end=' ')
+        print("%-7s"  % ( fstab[k]['mounted']), end=' ')
+        print("%-9s"   % ( str(fstab[k]['size']) + ' GiB'), end=' ')
+        print("%-8s"   % ( fstab[k]['status']), end=' ')
+        print("%-10s" % ( fstab[k]['pm_region']), end=' ')
+        print("%-8s"  % ( fstab[k]['pm_ns_dev']), end=' ')
+        print("%-8s"  % ( fstab[k]['pm_ns_type']), end=' ')
+        print("%-8s"  % ( fstab[k]['fs_type']), end=' ')
+        print("%-20s"  % ( fstab[k]['dimms']), end=' ')
+        print()
+
 
 def print_fs_mounts(fstab, status='ok', delimiter=';'):
     """
@@ -290,6 +297,14 @@ def print_fs_mounts(fstab, status='ok', delimiter=';'):
         if fstab[k]['status'] == status:
             print(fstab[k]['mount'], end=delimiter)
     print()
+
+def set_fs_mounted_state(fstab, dev, is_mounted):
+    if DEBUG: print("set_fs_status: dev:", dev, " status:", status)
+    fstab[dev]['mounted'] = bool(is_mounted)
+
+def set_ns_size(fstab, dev, size):
+    if DEBUG: print("set_fs_status: dev:", dev, " status:", status)
+    fstab[dev]['size'] = size
 
 def set_fs_status(fstab, dev, status='ok'):
     if DEBUG: print("set_fs_status: dev:", dev, " status:", status)

--- a/ndctl.py
+++ b/ndctl.py
@@ -283,13 +283,14 @@ def list_dimm_table():
     print()
     print("Optane Persistent Memory DIMM Status")
     print()
-    print("%-8s %-6s %-6s %-6s %-6s" % ("Linux", "DIMM", "DIMM", "Cntrl", "Remaining") )
-    print("%-8s %-6s %-6s %-6s %-6s" % ("Device", "Health", "Temp", "Temp", "Life") )
-    print("%-8s %-6s %-6s %-6s %-6s" % ("------", "------", "------", "------", "----") )
+    print("%-7s %-21s %-6s %-6s %-6s %-6s" % ("Linux", "DIMM", "DIMM", "DIMM", "Cntrl", "Remaining") )
+    print("%-7s %-21s %-6s %-6s %-6s %-6s" % ("Device", "UID", "Health", "Temp", "Temp", "Life") )
+    print("%-7s %-21s %-6s %-6s %-6s %-6s" % ("-------", "--------------------", "------", "------", "------", "----") )
 
     for x in range(len(ndctl['dimms'])):
-        print("%-8s %-6s %-6s %-6s %-6s" % (
+        print("%-7s %-21s %6s %-6s %-6s %-6s" % (
                 ndctl['dimms'][x]['dev'], \
+                ndctl['dimms'][x]['id'], \
                 ndctl['dimms'][x]['health']['health_state'], \
                 ndctl['dimms'][x]['health']['temperature_celsius'], \
                 ndctl['dimms'][x]['health']['controller_temperature_celsius'], \

--- a/pmt
+++ b/pmt
@@ -152,6 +152,19 @@ def main(argv):
             msg = "%s %s %s" % ("updating namespace status from dimm status", dev, status)
             message(msg,1)
             f.set_fs_status(fstab, dev, status)
+
+            # hack, hack, hack
+            mount_point = fstab[dev]['mount']
+            is_mounted = os.path.ismount(mount_point)
+            f.set_fs_mounted_state(fstab, dev, is_mounted)
+
+            # TODO
+            # ndctl['regions'][0]['namespaces'][0]['size']
+            #
+            #
+            size = int(1598128390144 / 1024 / 1024 / 1024)
+            f.set_ns_size(fstab, dev, size)
+
         msg = "%s %s %s" % ("done", '', '')
         message(msg,1)
 


### PR DESCRIPTION
Issue 1. Add mounted Yes/No column to fstab report
Issue 2. Add Filesystem capacity fs report
Issue 5. Remove 'OK' filter from fstab report to show status of all fs.

Optane Persistent Memory DIMM Status

Linux   DIMM                  DIMM   DIMM   Cntrl  Remaining
Device  UID                   Health Temp   Temp   Life
------- --------------------  ------ ------ ------ ----
nmem1   8089-a2-1836-0000214e     ok 31.0   32.0   100
nmem3   8089-a2-1836-000025c2     ok 31.0   35.0   100
nmem5   8089-a2-1836-000025fc     ok 32.0   34.0   100
nmem10  8089-a2-1836-00002639     ok 31.0   34.0   100
nmem7   8089-a2-1836-00001db5     ok 32.0   32.0   100
nmem9   8089-a2-1836-000020bf     ok 32.0   32.0   100
nmem0   8089-a2-1836-00002c4b     ok 32.0   34.0   100
nmem2   8089-a2-1836-00002716     ok 31.0   32.0   100
nmem4   8089-a2-1842-00002352     ok 31.0   32.0   100
nmem6   8089-a2-1836-000025be     ok 31.0   33.0   100
nmem11  8089-a2-1836-00002617     ok 30.0   32.0   100
nmem8   8089-a2-1836-00001e90     ok 31.0   33.0   100

Mount Point  Mounted NS Size   Health   Region     NS dev   NS Type  fs_type  PMEM Devices
------------ ------- --------- -------- ---------- -------- -------- -------- --------------------------------------
/pmemfs0     False   1488 GiB  ok       region0    pmem0    fsdaX    xfs      nmem5 nmem4 nmem3 nmem2 nmem1 nmem0
/pmemfs1     False   1488 GiB  ok       region1    pmem1    fsdaX    xfs      nmem11 nmem10 nmem9 nmem8 nmem7 nmem6

On branch issue03
Changes to be committed:
	modified:   fstab.py
	modified:   ndctl.py
	modified:   pmt